### PR TITLE
fix: confKeys merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All configuration options are explained in [Configuration](docs/config/config.md
 ## Installation
 Install globally:
 ```
-$ npm install npm install @ui5/uiveri5
+$ npm install @ui5/uiveri5
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/uiveri5",
-  "version": "1.35.4",
+  "version": "1.35.5",
   "description": "UIVeri5 is an E2E testing framework for UI5-based applications.",
   "author": "SAP SE (https://www.sap.com)",
   "license": "Apache-2.0",

--- a/spec/configParser.spec.js
+++ b/spec/configParser.spec.js
@@ -50,19 +50,28 @@ describe("Should parse confkey from command-line", function () {
     this._ = [];
   };
 
+  beforeEach(function() {
+    delete require.cache[require.resolve('../src/configParser')];
+    delete require.cache[require.resolve('../conf/default.conf.js')];
+    delete require.cache[require.resolve('../conf/profile.conf.js')];
+    delete require.cache[require.resolve('../conf/visual.profile.conf.js')];
+  });
+
   it('Should parse simple object notation in confkey', function () {
     var argvStub = new ArgvStub();
-    argvStub.confKeys = 'key1.key2:value';
+    argvStub.confKeys = 'key2.key2:value';
     var config = configParser.mergeConfigs(argvStub);
 
-    expect(config.key1).toEqual({key2: 'value'});
-    expect(config.confKeys).toEqual('key1.key2:value');
+    expect(config.key2).toEqual({key2: 'value'});
+    expect(config.confKeys).toEqual('key2.key2:value');
+    expect(config.confKeys).toEqual(argvStub.confKeys)
   });
 
   it('Should parse complex object notation in confkey', function () {
     var argvStub = new ArgvStub();
     argvStub.confKeys = 'key1[0].key2:value';
     var config = configParser.mergeConfigs(argvStub);
+
 
     expect(config.key1).toEqual([{key2: 'value'}]);
     expect(config.confKeys).toEqual('key1[0].key2:value');
@@ -73,7 +82,7 @@ describe("Should parse confkey from command-line", function () {
     argvStub.confKeys = ['key1.key2:value','key1.key3:value1'];
     var config = configParser.mergeConfigs(argvStub);
 
-    expect(config.key1).toContain({key2: 'value',key3: 'value1'});
+    expect(config.key1).toEqual({key2: 'value',key3: 'value1'});
     expect(config.confKeys).toEqual(['key1.key2:value','key1.key3:value1']);
   });
 
@@ -82,7 +91,7 @@ describe("Should parse confkey from command-line", function () {
     argvStub.confKeys = 'key1.key2:value;key1.key3:value1';
     var config = configParser.mergeConfigs(argvStub);
 
-    expect(config.key1).toContain({key2: 'value',key3: 'value1'});
+    expect(config.key1).toEqual({key2: 'value',key3: 'value1'});
     expect(config.confKeys).toContain('key1.key2:value;key1.key3:value1');
   });
 });

--- a/spec/configParser/conf.js
+++ b/spec/configParser/conf.js
@@ -3,6 +3,7 @@ exports.config = {
   multi: [
     {name: 'option1'}
   ],
+  key1: [{key2: 'changeme'}],
   test: {
     key: {
       param: 'sap-ui-theme=sap_${parameters.test}',

--- a/spec/localUI5SpecResolver.spec.js
+++ b/spec/localUI5SpecResolver.spec.js
@@ -9,7 +9,7 @@ describe("LocalUI5SpecResolver", function () {
     specResolver.resolve().then(function(specs){
       expect(specs[0]).toEqual({name:'Comp1',fullName:'sap.m.Comp1',lib: 'sap.m',branch: 'overwrite',
        testPath: __dirname.replace(/\\/g,'/') + '/localUI5SpecResolver/openui5/src/sap.m/test/sap/m/visual/Comp1.spec.js',
-       contentUrl:'http://localhost:8080/testsuite/test-resources/sap/m/Comp1.html'});
+       contentUrl:'http://localhost:8080/test-resources/sap/m/Comp1.html'});
       done();
     }).catch(function(error){
       fail(error);
@@ -23,7 +23,7 @@ describe("LocalUI5SpecResolver", function () {
     specResolver.resolve().then(function(specs){
       expect(specs[0]).toEqual({name:'Comp1',fullName:'sap.gantt.Comp1',lib: 'sap.gantt',branch: 'overwrite',
         testPath: __dirname.replace(/\\/g,'/') + '/localUI5SpecResolver/sap.gantt/gantt.lib/test/sap/gantt/visual/Comp1.spec.js',
-        contentUrl:'http://localhost:8080/testsuite/test-resources/sap/gantt/Comp1.html'});
+        contentUrl:'http://localhost:8080/test-resources/sap/gantt/Comp1.html'});
       done();
     }).catch(function(error){
       fail(error);

--- a/src/configParser.js
+++ b/src/configParser.js
@@ -21,6 +21,8 @@ ConfigParser.prototype.mergeConfigs = function (config) {
   // apply common profile
   this._mergeConfig('../conf/profile.conf.js', 'common profile');
 
+  // Changing config via confKeys
+  this._setConfKeys();
   // return new fully merged config
   return this.config;
 };
@@ -46,6 +48,21 @@ ConfigParser.prototype.resolvePlaceholders = function(obj) {
   return obj;
 };
 
+ConfigParser.prototype._setConfKeys =  function() {
+  var confKeys = this.config.confKeys;
+  var config = this.config;
+  if (confKeys) {
+    if (_.isArray(confKeys)) {
+      _.forEach(confKeys,function(key) {
+        _setConfKey(config,key);
+      });
+    } else {
+      _setConfKey(config,confKeys);
+    }
+  }
+  this.config = config;
+};
+
 function _setConfKey(config,confKey) {
   var pairs = confKey.split(';');
   _.forEach(pairs,function(pair) {
@@ -58,17 +75,7 @@ function _setConfKey(config,confKey) {
 }
 
 function _mergeWithArrays(object, src) {
-  var config = src;
-  var confKeys = config.confKeys;
-  if (confKeys) {
-    if (_.isArray(confKeys)) {
-      _.forEach(confKeys,function(confKeys) {
-        _setConfKey(config,confKeys);
-      });
-    } else {
-      _setConfKey(config,confKeys);
-    }
-  }
+  // return _.merge(object, src)
   return _.mergeWith(object, src, function (objectValue, sourceValue) {
     // return undefined to use _.merge default strategy
     if (_.isArray(objectValue) && sourceValue) {


### PR DESCRIPTION
In order to be able to overwrite objectKeys inside Arrays, for example
browsers[0].browserName:firefox, without creating extra object, confKeys
needs to be separated from _mergeWithArrays, that is called several
times, therefore creating new objectKey before reaching the actual place
where it needs to ._set the objectKey inside Object defined in config.