### PR TITLE
feat: --browsers argument priority

### DIFF
--- a/spec/configParser.spec.js
+++ b/spec/configParser.spec.js
@@ -46,6 +46,7 @@ describe("configParser", function() {
 describe("Should parse confkey from command-line", function () {
   var logger = require('../src/logger')(3);
   var configParser = require('../src/configParser')(logger);
+  var cliParser = new require('../src/cliParser')();
   var ArgvStub = function () {
     this._ = [];
   };
@@ -84,5 +85,14 @@ describe("Should parse confkey from command-line", function () {
 
     expect(config.key1).toContain({key2: 'value',key3: 'value1'});
     expect(config.confKeys).toContain('key1.key2:value;key1.key3:value1');
+  });
+
+  it('Should overwrite config.browsers with --browsers', () => {
+    var argvStub = new ArgvStub();
+    argvStub.browsers = 'firefox';
+    var parsed = cliParser.parse(argvStub) 
+    var config = configParser.mergeConfigs(parsed)
+    
+    expect(config.browsers).toEqual([{"browserName": "firefox"}])
   });
 });

--- a/spec/configParser/conf.js
+++ b/spec/configParser/conf.js
@@ -8,5 +8,8 @@ exports.config = {
       param: 'sap-ui-theme=sap_${parameters.test}',
       secondParam: "sap-ui-rtl=${parameters.rtl === 'rtl'}"
     }
-  }
+  },
+  browsers: [{
+    browserName: 'chrome'
+  }]
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,7 @@ var argv = require('yargs').
   boolean('seleniumLoopback').
   describe('seleniumLoopback', 'Bind the selenium server listener port to loopback interface.').
   string('browsers').
-  describe('browsers', 'Comma separated list of browsers to execute tests, defaults to chrome').
+  describe('browsers', 'Comma separated list of browsers to execute tests, overwrites *.conf.js values, defaults to chrome').
   describe('params', 'Param object to be passed to the tests').
   describe('timeouts', 'Timeouts').
   string('config').

--- a/src/configParser.js
+++ b/src/configParser.js
@@ -29,6 +29,11 @@ ConfigParser.prototype._mergeConfig = function (configFile, type) {
   this.logger.debug('Loading ' + type + ' config from: ' + configFile);
   var config = require(configFile).config;
 
+  // if browsers are defined in both *.conf.js and command line, use command line parameters
+  if (this.config.browsers && config.browsers) {
+    this.logger.info('Browsers defined in both *.conf.js and --browsers CLI argument, using --browsers argument.');
+    delete config.browsers;
+  }
   // merge the loaded *.conf.js file with command line parameters
   this.config = _mergeWithArrays(config, this.config);
 };

--- a/src/uiveri5.js
+++ b/src/uiveri5.js
@@ -21,7 +21,7 @@ var DEFAULT_CONNECTION_NAME = 'direct';
  * @property {number} verbose - verbose level, 0 shows only info, 1 shows debug,
  *  2 shows waitForUI5 executions,3 shows also waitForUI5 script content, defaults t: 0
  * @property {<BrowserCapability|String}>[]} browsers - list of browsers to drive. Single word is assumed to
- *  be browserName, supports column delimited and json formats, defaults to: 'chrome'
+ *  be browserName, supports column delimited and json formats, overwrites *.conf.js values, defaults to: 'chrome'
  * @property {Object} params - params object to be passed to the tests
  * @property {boolean} ignoreSync - disables waitForUI5 synchronization, defaults to: false
  * @property {boolean} useClassicalWaitForUI5 - use classical version of waitForUI5, defaults to: false

--- a/src/uiveri5.js
+++ b/src/uiveri5.js
@@ -475,8 +475,8 @@ function run(config) {
           
           // log UI5 version
           return browser.executeScriptWithDescription(clientsidescripts.getUI5Version, 'browser.getUI5Version').then(function (versionInfo) {
-            logger.info("UI5 Version: " + versionInfo.version);
-+           logger.info("UI5 Timestamp: " + versionInfo.buildTimestamp);
+            logger.info('UI5 Version: ' + versionInfo.version);
+            logger.info('UI5 Timestamp: ' + versionInfo.buildTimestamp);
           });
         },
 


### PR DESCRIPTION
I believe that because of proxyquire usage to mock direct connection
provider it is much better to use --browsers as cli overwrite for
browsers inside *.conf.js,  as it won't be possible to run multiple browsers without major
refactoring.

And by major, I believe that without ability to mock requires in nodejs child processes(which I have no idea how to do), we won't be able to rewrite connection providers as beforeLaunch is not run correctly with multiCapabilities:
https://github.com/angular/protractor/issues/3590

That means we'd have to sequentially run protractor.init without multiple instances, and handle this inside uiveri5.