### PR TITLE
On prepare config

### DIFF
--- a/src/uiveri5.js
+++ b/src/uiveri5.js
@@ -588,6 +588,7 @@ function run(config) {
         reporter.register(jasmineEnv);
       });
 	  
+	  // call onPrepare, given from conf.js
 	  if(config.onPrepare && typeof config.onPrepare === "function"){
 		  config.onPrepare.apply(this, logger);
 	  }

--- a/src/uiveri5.js
+++ b/src/uiveri5.js
@@ -587,6 +587,10 @@ function run(config) {
       moduleLoader.loadModule('reporters',[statisticCollector]).forEach(function(reporter){
         reporter.register(jasmineEnv);
       });
+	  
+	  if(config.onPrepare && typeof config.onPrepare === "function"){
+		  config.onPrepare.apply(this, logger);
+	  }
     };
 
     protractorArgv.afterLaunch = function(){


### PR DESCRIPTION
Protractor offers the possibility, to execute a onPrepare function.
With this pull request, it is possible to define a `onPrepare` function in the conf.js, which is executed at the end of the uiveri5's `protractorArgv.onPrepare` function.
With this hook it is possible to add e. g. custom reporters to uiveri5 (e. g. [jasmine-fail-fast](https://www.npmjs.com/package/jasmine-fail-fast)).