### PR TITLE
update WebDriver name for Microsoft Edge (Chromium)

### DIFF
--- a/src/connection/directConnectionProvider.js
+++ b/src/connection/directConnectionProvider.js
@@ -197,7 +197,7 @@ DirectConnectionProvider.prototype.setupEnv = function() {
       } else if (browserName == 'edge') {
         promises.push((function() {
           var deferred = q.defer();
-          var filename = path.join(that._getSeleniumRoot(), 'MicrosoftWebDriver.exe');
+          var filename = path.join(that._getSeleniumRoot(), 'msedgedriver.exe');
           that.seleniumConfig.executables.edgedriver = filename;
           deferred.resolve(filename);
           return deferred.promise;


### PR DESCRIPTION
-the webdriver for Microsoft Edge (Chromium) is msedgedriver.exe
-the webdriver for Microsoft Edge Legacy is MicrosoftWebDriver.exe (if you need to support Legacy version you need to have a new entry for edge_legacy)

-this code change was tested successfully with Microsoft Edge Chromium x64 Release 79
-see also my previous pull request for documentation update drivers.md

https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/