### PR TITLE
Remove validation of capabilities when running with Selenium Hub

### DIFF
--- a/src/connection/directConnectionProvider.js
+++ b/src/connection/directConnectionProvider.js
@@ -71,22 +71,25 @@ DirectConnectionProvider.prototype.resolveCapabilitiesFromRuntime = function(run
   // save this runtime so setupEnv() could download respective drivers
   this.runtimes.push(runtime);
 
-  var capabilities = {};
+  // default capabilities with capabilities provided in the config already
+  var capabilities = Object.assign({}, runtime.capabilities || {});
 
   // capabilities according:
   // https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities
   // http://appium.io/slate/en/master/?ruby#appium-server-capabilities
 
   // format browserName
-  if (runtime.platformName === 'android' || runtime.platformName === 'ios') {
-    capabilities.browserName = runtime.browserName.charAt(0).toUpperCase() + runtime.browserName.slice(1);
-  } else {
-    if (runtime.browserName === 'ie') {
-      capabilities.browserName = 'internet explorer';
-    } else if (runtime.browserName === 'edge') {
-      capabilities.browserName = 'MicrosoftEdge';
+  if (!capabilities.browserName) {
+    if (runtime.platformName === 'android' || runtime.platformName === 'ios') {
+      capabilities.browserName = runtime.browserName.charAt(0).toUpperCase() + runtime.browserName.slice(1);
     } else {
-      capabilities.browserName = runtime.browserName;
+      if (runtime.browserName === 'ie') {
+        capabilities.browserName = 'internet explorer';
+      } else if (runtime.browserName === 'edge') {
+        capabilities.browserName = 'MicrosoftEdge';
+      } else {
+        capabilities.browserName = runtime.browserName;
+      }
     }
   }
 
@@ -96,39 +99,41 @@ DirectConnectionProvider.prototype.resolveCapabilitiesFromRuntime = function(run
   }
 
   // format platformName
-  if (runtime.platformName === 'windows') {
-    if (runtime.platformVersion === '*') {
-      capabilities.platform = 'WINDOWS';
-    } else if (runtime.platformVersion === 'XP') {
-      capabilities.platform = 'XP';
-    } else if (runtime.platformVersion === 'VISTA' || runtime.platformVersion === '7') {
-      capabilities.platform = 'VISTA';
-    } else if (runtime.platformVersion === '8') {
-      capabilities.platform = 'WIN8';
-    } else if (runtime.platformVersion === '8.1') {
-      capabilities.platform = 'WIN8_1';
+  if (!capabilities.platform && !capabilities.platformName) {
+    if (runtime.platformName === 'windows') {
+      if (runtime.platformVersion === '*') {
+        capabilities.platform = 'WINDOWS';
+      } else if (runtime.platformVersion === 'XP') {
+        capabilities.platform = 'XP';
+      } else if (runtime.platformVersion === 'VISTA' || runtime.platformVersion === '7') {
+        capabilities.platform = 'VISTA';
+      } else if (runtime.platformVersion === '8') {
+        capabilities.platform = 'WIN8';
+      } else if (runtime.platformVersion === '8.1') {
+        capabilities.platform = 'WIN8_1';
+      } else {
+        throw Error('Platform version: ' + runtime.platformVersion +
+        ' for platformName: WINDOWS is not supported by directConnectionProvider');
+      }
+    } else if (runtime.platformName === 'linux' || runtime.platformName === 'mac') {
+      capabilities.platform = runtime.platformName.toUpperCase();
+    } else if (runtime.platformName === 'ios') {
+      capabilities.platformName = 'iOS';
+    } else if (runtime.platformName === 'android') {
+      capabilities.platformName = 'Android';
     } else {
-      throw Error('Platform version: ' + runtime.platformVersion +
-      ' for platformName: WINDOWS is not supported by directConnectionProvider');
+      throw Error('Platform name: ' + runtime.platformName +	
+        ' not supported by directConnectionProvider');	
     }
-  } else if (runtime.platformName === 'linux' || runtime.platformName === 'mac') {
-    capabilities.platform = runtime.platformName.toUpperCase();
-  } else if (runtime.platformName === 'ios') {
-    capabilities.platformName = 'iOS';
-  } else if (runtime.platformName === 'android') {
-    capabilities.platformName = 'Android';
-  } else {
-    throw Error('Platform name: ' + runtime.platformName +	
-      ' not supported by directConnectionProvider');	
   }
 
   // format platformVersion
-  if (runtime.platformVersion !== '*'){
+  if (!capabilities.platformVersion && runtime.platformVersion !== '*'){
     capabilities.platformVersion = runtime.platformVersion;
   }
 
   // format deviceName
-  if (runtime.deviceName !== '*'){
+  if (!capabilities.deviceName && runtime.deviceName !== '*'){
     capabilities.deviceName = runtime.deviceName;
   }
 

--- a/src/runtimeResolver.js
+++ b/src/runtimeResolver.js
@@ -82,6 +82,7 @@ function RuntimeResolver(config,logger){
 RuntimeResolver.prototype.resolveRuntimes = function(){
   var that = this;
   var runtimes = this.config.browsers;
+  var runningAgainstSeleniumHub = !!this.config.seleniumAddress;
 
   // no runtimes => run on chrome
   if (!runtimes) {
@@ -94,16 +95,22 @@ RuntimeResolver.prototype.resolveRuntimes = function(){
     if (!runtime.browserName){
       throw Error('Browser name not specified');
     }
-    if(supportedBrowserNames.indexOf(runtime.browserName)==-1){
+    if(!runningAgainstSeleniumHub && supportedBrowserNames.indexOf(runtime.browserName)==-1){
+      // NOTE: when running against Selenium Hub, it doesn't matter what UIveri5 supports,
+      // but what the Selenium Hub supports
       throw Error('Browser: ' + runtime.browserName + ' is not supported, use one of: ' +
         JSON.stringify(supportedBrowserNames));
     }
 
     // handle platformName
-    if(!runtime.platformName){
+    if(!runningAgainstSeleniumHub && !runtime.platformName){
+      // NOTE: when running against Selenium Hub, it doesn't make sens to derive the platformName
+      // from the host OS
       runtime.platformName = platformNamePerOsTypeString[that.config.osTypeString];
     }
-    if(supportedPlatformNames.indexOf(runtime.platformName)==-1){
+    if(!runningAgainstSeleniumHub && supportedPlatformNames.indexOf(runtime.platformName)==-1){
+      // NOTE: when running against Selenium Hub, it doesn't matter what UIveri5 supports,
+      // but what the Selenium Hub supports
       throw Error('Platform: ' + runtime.platformName + ' is not supported, use one of: ' +
         JSON.stringify(supportedPlatformNames));
     }


### PR DESCRIPTION
**tl;dr**

This PR makes UIveri5 work properly with Selenium Hub implementations by removing validations of the configuration when a `seleniumAddress` is configured and by preventing to overwrite explicit configuration.

---

In the current implementation, UIveri5 validates the the `browser` settings and only allows a certain range of values (see [Browsers](https://github.com/SAP/ui5-uiveri5/blob/master/docs/config/config.md#browsers) in docs).

This is perfectly reasonable for when I want to run UIveri5 on my local machine with my local browsers. For example, on macOS, of course there's no IE11, so running such a config wouldn't make sense. Or on a Windows machine, configuring UIveri5 to run against Safari doesn't make sense.

So far so good.

However, when I want to make use of [remote execution](https://github.com/SAP/ui5-uiveri5/blob/master/docs/config/config.md#remote-execution) and configure a `seleniumAddress`, the validation of the capabilities configured in my UIveri5 config don't make sense.

Because with a Selenium Hub, of course I should be able to run my tests in IE11 (assuming that it's supported by the Selenium Hub), no matter whether I run UIveri5 from Windows or macOS.

But just removing any checks against the host OS is not sufficient. In the current implementation, UIveri5 also has checks on the capabilities of the browser, derives values, does some defaulting, etc.

When using a Selenium Hub, it shouldn't make any changes to browser capabilities.

To support this point, let's for example take a look at the capabilities that you would need to configure for running UIveri5 against Edge with a) BrowserStack and b) Sauce Labs as Selenium Hub implementations:

In BrowserStack:

```javascript
var capabilities = {
"os" : "Windows",
"os_version" : "10",
"browserName" : "Edge",
"browser_version" : "81.0 beta",
"browserstack.local" : "false",
"browserstack.selenium_version" : "3.5.2",
"browserstack.user" : "USERNAME",
"browserstack.key" : "ACCESS_KEY"
}
```

In Sauce Labs:

```javascript
var capabilities = {
  "browserName": 'MicrosoftEdge',
  "browserVersion": 'latest',
  "platformName": 'Windows 10',
  "sauce:options": {
  }
}
```

The capabilities differ significantly, and UIveri5 shouldn't validate them when using a Selenium Hub.

Here are the specific references to the code:

- In the [runtimeResolve.js](https://github.com/SAP/ui5-uiveri5/blob/503818b2a619d8d779655339621926487e098d0d/src/runtimeResolver.js#L103-L109), the platform name is defaulted to the host OS and even with explicit configuration, only certain platforms are supported. When running against Selenium Hub, defaulting to the host OS doesn’t make sense, because browsers, etc. won’t be restricted by the host OS but by the capabilities of the Selenium Hub. Also, in the Selenium Hub scenario, the allowed values for the platform shouldn’t be restricted to a predefined enum. They depend solely on the capabilities of the Selenium Hub and can therefore not be checked in UIveri5.
- In the [directConnectionProvider.js](https://github.com/SAP/ui5-uiveri5/blob/84ed13197aa9d69f4c9dc12e089260fbb8bbec77/src/connection/directConnectionProvider.js#L70), the capabilities of the browser are overwritten (and partially defaulted by the host OS), regardless of whether they are already defined or not. As stated above, deriving something based on the host OS doesn’t make sense in the Selenium Hub scenario. Also, overwriting capabilities IMO doesn’t make sense. Again, Selenium Hub implementations might vary, and UIveri5 would never be able to check for all possible values, combinations, etc.

